### PR TITLE
added case class extraction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,27 +8,40 @@ lazy val root = project.in(file(".")).
   settings(
     publish := {},
     publishLocal := {},
-    crossScalaVersions := Seq("2.11.5", "2.10.4")
-
-
+    crossScalaVersions := Seq("2.11.6", "2.10.4")
 )
+
+/**
+ * Project for macroses
+ */
+lazy val macs = crossProject.in(file("macs")).settings(
+  scalaVersion := "2.11.6",
+  name := "macs",
+  version := "0.1",
+  crossScalaVersions := Seq("2.11.6", "2.10.4"),
+  resolvers += Resolver.sonatypeRepo("releases"),
+  libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _),
+  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full)
+)
+
+lazy val macrosesJVM = macs.jvm
+lazy val macrosesJS = macs.js
 
 lazy val pc = crossProject.in(file(".")).
   settings(
     libraryDependencies += "com.lihaoyi" %%% "utest" % "0.3.0",
     testFrameworks += new TestFramework("utest.runner.Framework"),
-    scalaVersion := "2.11.5",
-    crossScalaVersions := Seq( "2.10.4","2.11.5"),
+    scalaVersion := "2.11.6",
+    crossScalaVersions := Seq("2.11.6", "2.10.4"),
     sourceDirectories in Compile += new File("./shared/src/"),
     name := "product-collections",
     organization :="com.github.marklister",
     version := "1.4.0",
-    scalaVersion := "2.11.5",
+    scalaVersion := "2.11.6",
     homepage := Some(url("https://github.com/marklister/product-collections")),
     startYear := Some(2013),
     description := "Lightweight 2D Data framework.  Strongly typed CSV I/O.  Statistics.",
     licenses += ("BSD Simplified", url("http://opensource.org/licenses/BSD-SIMPLIFIED")),
-
     pomExtra := (
       <scm>
         <url>git@github.com:marklister/product-collections.git</url>
@@ -44,18 +57,18 @@ lazy val pc = crossProject.in(file(".")).
     scalacOptions in (Compile, doc) ++= Opts.doc.title("product-collections"),
     apiURL := Some(url("http://marklister.github.io/product-collections/target/scala-2.11/api/")),
     scalacOptions in (Compile, doc) ++= Seq("-implicits")
-  ).settings(Boilerplate.settings: _ *)
+  ).settings(Boilerplate.settings: _ *).dependsOn(macs)
   //.settings(bintraySettings:_*)  //REMOVE FROM PUBLISHED build.sbt
-
   .jvmSettings(
     libraryDependencies ++= Seq("net.sf.opencsv" % "opencsv" % "2.3"),
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full),
     initialCommands in console := """
   import com.github.marklister.collections.io._
   import com.github.marklister.collections._
                                   """
   )
   .jsSettings(
-
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full)
   )
 
 lazy val productCollectionsJVM = pc.jvm

--- a/macs/shared/src/main/scala/collections/annotations/CaseColSeq.scala
+++ b/macs/shared/src/main/scala/collections/annotations/CaseColSeq.scala
@@ -1,0 +1,19 @@
+package collections.annotations
+
+import scala.collection.immutable.VectorBuilder
+import scala.collection.{IndexedSeqLike, mutable}
+import scala.language.experimental.macros
+
+
+class CaseColSeq[T](val underlying: Seq[T] ) extends IndexedSeq[T] with IndexedSeqLike [T, CaseColSeq[T]]
+ {
+   override protected[this] def newBuilder = CaseColSeq.newBuilder
+   override def apply (idx: Int): T = underlying (idx)
+   lazy val length: Int = underlying.length
+ }
+
+object CaseColSeq {
+
+   def apply[T] (x: Seq[T] ): CaseColSeq[T] = new CaseColSeq(x)
+   def newBuilder[T]: mutable.Builder[T, CaseColSeq[T]] = new VectorBuilder mapResult apply
+ }

--- a/macs/shared/src/main/scala/collections/annotations/extract.scala
+++ b/macs/shared/src/main/scala/collections/annotations/extract.scala
@@ -1,0 +1,53 @@
+package collections.annotations
+
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+
+
+@compileTimeOnly("enable macro paradise to expand macro annotations")
+class extract extends StaticAnnotation {
+   def macroTransform(annottees: Any*) = macro extractMacro.impl
+ }
+
+
+object extractMacro {
+  def impl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+
+    def companion( classDecl: ClassDef,compDeclOpt: Option[ModuleDef] = None) = {
+      val q"case class $className(..$fields) extends ..$bases { ..$body }" = classDecl
+      val names:Seq[ValDef] =  fields
+      val vals = names.map { case v =>   q"lazy val ${(v.name+"s"):TermName}:Seq[${v.tpt}] = args.map(a=>a.${v.name}).toSeq"     }
+      q"""
+          object ${className.toTermName}
+          {
+            class Columns(args:Seq[${className.toTypeName}]) extends collections.annotations.CaseColSeq[${className.toTypeName}](args){
+              ..$vals
+            }
+
+            def asFrame(args:${className.toTypeName}*):Columns= new Columns(args)
+          }
+        """
+    }
+
+    def updatedDecl(classDecl: ClassDef, compDeclOpt: Option[ModuleDef] = None) = {
+      //val (className,fields) = extractNameWithFields(classDecl)
+      val compDecl = companion(classDecl,compDeclOpt)
+
+      c.Expr(q"""
+        $classDecl
+        $compDecl
+      """)
+    }
+    annottees.map(_.tree) match
+    {
+      case  (classDecl: ClassDef) :: Nil => updatedDecl(classDecl,None)
+      case (classDecl: ClassDef) :: (compDecl: ModuleDef) :: Nil => updatedDecl(classDecl,Some(compDecl))
+      case _ => c.abort(c.enclosingPosition, "Invalid annottee")
+    }
+
+  }
+
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0")
-
-//addSbtPlugin("com.lihaoyi" % "utest-js-plugin" % "0.2.4")
-
-//addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.5.9") //alternatively we use the source in git see project/project/build.scala
-
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.2")
 
 
 

--- a/shared/src/test/scala/CaseColSeqTest.scala
+++ b/shared/src/test/scala/CaseColSeqTest.scala
@@ -1,0 +1,25 @@
+import collections.annotations.extract
+import utest._
+import utest.framework.TestSuite
+import collections.annotations._
+
+
+object CaseColSeqTest extends TestSuite{
+
+  @extract case class User(name:String,surname:String)
+  val tests = TestSuite{
+
+    "Should create Data Frames from case classes" -{
+
+      val (ann,bob) = (User("Ann","Cute"),User("Bob","Ugly"))
+      val frame = User.asFrame(ann,bob)
+      val names:Seq[String] = frame.names
+      val surnames:Seq[String] = frame.surnames
+      assert(names.size==2)
+      assert(surnames.size==2)
+      assert(names==Seq("Ann","Bob"))
+      assert(surnames==Seq("Cute","Ugly"))
+    }
+
+  }
+}


### PR DESCRIPTION
I added creation from case classes.
Here how it works

``` scala
@extract case class User(name:String,surname:String)
  val tests = TestSuite{
    "Should create Data Frames from case classes" -{

      val (ann,bob) = (User("Ann","Cute"),User("Bob","Ugly"))
      val frame = User.asFrame(ann,bob)
      val names:Seq[String] = frame.names
      val surnames:Seq[String] = frame.surnames
      assert(names.size==2)
      assert(surnames.size==2)
      assert(names==Seq("Ann","Bob"))
      assert(surnames==Seq("Cute","Ugly"))
    }
  }
```

Macro annotations automaticly add `asFrame` method to companion object of a case class. In case of User it will be User.asFrame(someusers:_*) that will return User.Columns class where you can get Columns by case accesors names+"s", in our case: User.names, User.surnames
